### PR TITLE
Events Phase 1: local events + contacts + AI parsing (SB-125)

### DIFF
--- a/src/todo/ai/event_parser.py
+++ b/src/todo/ai/event_parser.py
@@ -1,0 +1,103 @@
+"""AI parsing of natural-language event descriptions into structured drafts.
+
+The model only *extracts* fields and the raw date/time phrases — it does NOT
+compute absolute dates (small models are unreliable at weekday arithmetic).
+The caller resolves the phrases deterministically via ``core.dates``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from .providers import ProviderManager
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from ..models import AIProvider
+
+EVENT_PARSE_PROMPT = """
+You extract a single calendar event from a short natural-language description.
+Extract fields literally — do NOT compute or resolve dates yourself.
+
+- title: the event summary, with the date/time and invitee phrases removed.
+- date_phrase: the date expression exactly as written (e.g. "friday",
+  "next monday", "tomorrow", "june 12", "6/14"). Empty string if none given.
+- time: the clock time exactly as written (e.g. "7pm", "noon", "9:30am",
+  "14:30"). null if no specific time is given.
+- end_time: the end clock time if given, else null.
+- duration_minutes: the duration in minutes if stated (e.g. "for 90 minutes"),
+  else null.
+- location: the location if mentioned, else null.
+- attendees: people to invite — tokens after "invite", "with", "for" — as
+  lowercase aliases (e.g. "wife", "kids") or email addresses.
+
+Do not invent details that are not present.
+""".strip()
+
+
+class EventDraft(BaseModel):
+    """Fields extracted from a natural-language event description.
+
+    Date/time are returned as raw phrases for deterministic resolution by the
+    caller — never as computed absolute datetimes.
+    """
+
+    title: str = Field(..., description="Event title/summary")
+    date_phrase: str = Field(
+        "", description="Date expression as written, e.g. 'friday', 'tomorrow'"
+    )
+    time: str | None = Field(
+        None, description="Clock time as written, e.g. '7pm'; null if none"
+    )
+    end_time: str | None = Field(None, description="End clock time if given")
+    duration_minutes: int | None = Field(
+        None, description="Duration in minutes if stated"
+    )
+    location: str | None = Field(None, description="Location if mentioned")
+    attendees: list[str] = Field(
+        default_factory=list,
+        description="Aliases or emails to invite (e.g. wife, kids)",
+    )
+
+
+class EventParser:
+    """Extract event fields from natural language using the AI provider."""
+
+    def __init__(self) -> None:
+        self.provider_manager = ProviderManager()
+
+    async def parse(
+        self,
+        text: str,
+        now: datetime,
+        preferred_provider: AIProvider | None = None,
+    ) -> EventDraft | None:
+        """Extract an :class:`EventDraft` from ``text``.
+
+        Args:
+            text: The natural-language event description.
+            now: Reference datetime (passed to the model for context only;
+                date math is done by the caller).
+            preferred_provider: Optional provider override.
+
+        Returns:
+            The extracted draft, or None if no provider is available or the
+            call fails.
+        """
+        provider = await self.provider_manager.get_available_provider(
+            preferred_provider
+        )
+        if not provider:
+            return None
+
+        prompt = f"{EVENT_PARSE_PROMPT}\n\nFor context, today is {now:%Y-%m-%d %A}."
+        try:
+            agent = await provider.create_agent(prompt, EventDraft)
+            result = await agent.run(text)
+            return result.output
+        except Exception as e:  # pragma: no cover - network/provider errors
+            print(f"Event parsing failed: {e}")
+            return None

--- a/src/todo/cli/main.py
+++ b/src/todo/cli/main.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+from datetime import date, datetime, timedelta
+from datetime import time as dt_time
 from typing import Any
 
 import typer
@@ -10,11 +12,17 @@ from rich.table import Table
 
 from ..ai.background import BackgroundEnrichmentService
 from ..ai.enrichment_service import EnrichmentService
+from ..ai.event_parser import EventParser
 from ..core.config import get_app_config
-from ..core.dates import parse_due_date
+from ..core.dates import parse_datetime, parse_due_date
 from ..db.connection import DatabaseConnection
 from ..db.migrations import MigrationManager
-from ..db.repository import AIEnrichmentRepository, TodoRepository
+from ..db.repository import (
+    AIEnrichmentRepository,
+    ContactRepository,
+    EventRepository,
+    TodoRepository,
+)
 from ..models import AIProvider
 
 console = Console()
@@ -35,6 +43,9 @@ todo_repo = None
 ai_repo = None
 enrichment_service = None
 background_service = None
+event_repo = None
+contact_repo = None
+event_parser = None
 
 
 def _initialize_services():
@@ -46,7 +57,10 @@ def _initialize_services():
         todo_repo, \
         ai_repo, \
         enrichment_service, \
-        background_service
+        background_service, \
+        event_repo, \
+        contact_repo, \
+        event_parser
 
     if db is not None:
         return  # Already initialized
@@ -71,6 +85,9 @@ def _initialize_services():
         ai_repo = AIEnrichmentRepository(db)
         enrichment_service = EnrichmentService(db)
         background_service = BackgroundEnrichmentService(db)
+        event_repo = EventRepository(db)
+        contact_repo = ContactRepository(db)
+        event_parser = EventParser()
     except RuntimeError as e:
         # Handle database lock errors gracefully
         console.print(f"[red]✗ Database Error:[/red] {e}")
@@ -139,6 +156,24 @@ def _todo_to_dict(todo: Any, ai_enrichment: Any = None) -> dict[str, Any]:
         "created_at": todo.created_at,
         "completed_at": todo.completed_at,
         "ai_enriched": ai_enrichment is not None,
+    }
+
+
+def _event_to_dict(event: Any) -> dict[str, Any]:
+    """Serialize an Event to a plain dict."""
+    return {
+        "id": event.id,
+        "title": event.title,
+        "description": event.description,
+        "start_at": event.start_at,
+        "end_at": event.end_at,
+        "all_day": event.all_day,
+        "location": event.location,
+        "status": _enum_val(event.status),
+        "attendees": list(event.attendees),
+        "google_event_id": event.google_event_id,
+        "is_synced": event.is_synced,
+        "created_at": event.created_at,
     }
 
 
@@ -1385,6 +1420,360 @@ def delete_goal(goal_id: int = typer.Argument(..., help="Goal ID to delete")) ->
 
 
 app.add_typer(goal_app, name="goal")
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+event_app = typer.Typer(help="Calendar event management")
+
+
+def _emit_error(out, json_out: bool, message: str) -> None:
+    """Report an error to stderr/console, and as JSON when in --json mode."""
+    out.print(f"[red]✗ {message}[/red]")
+    if json_out:
+        _emit_json({"error": message})
+
+
+@event_app.command("add")
+def event_add(
+    text: str,
+    when: str | None = typer.Option(
+        None, "--when", "-w", help="Date/time for flag mode, e.g. '2026-06-12 19:00'"
+    ),
+    duration: int | None = typer.Option(None, "--duration", help="Duration in minutes"),
+    end: str | None = typer.Option(None, "--end", help="Explicit end date/time"),
+    location: str | None = typer.Option(None, "--location", "-L"),
+    description: str | None = typer.Option(None, "--desc", "-d"),
+    invite: str | None = typer.Option(
+        None, "--invite", "-i", help="Comma-separated aliases/emails to invite"
+    ),
+    no_ai: bool = typer.Option(False, "--no-ai", help="Skip AI parsing; use flags"),
+    json_out: bool = typer.Option(
+        False, "--json", "-j", help="Emit result as JSON (machine-readable)"
+    ),
+) -> None:
+    """Add a calendar event from natural language or explicit flags.
+
+    Examples:
+        todo event add "dinner with parents friday 7pm, invite wife and kids"
+        todo event add "Dinner" --when "2026-06-12 19:00" --invite wife,kids --no-ai
+    """
+    _initialize_services()
+    out = console_err if json_out else console
+
+    title = text.strip()
+    end_at = None
+    all_day = False
+    attendee_tokens: list[str] = []
+
+    if no_ai or when:
+        # Flag mode.
+        if not when:
+            _emit_error(out, json_out, "Flag mode needs --when (or use AI parsing)")
+            return
+        try:
+            start_at = parse_datetime(when)
+            if end:
+                end_at = parse_datetime(end)
+        except ValueError as e:
+            _emit_error(out, json_out, str(e))
+            return
+        if invite:
+            attendee_tokens = [t.strip() for t in invite.split(",") if t.strip()]
+    else:
+        # AI mode: the model extracts raw phrases; we resolve dates ourselves.
+        draft = asyncio.run(event_parser.parse(text, datetime.now()))
+        if not draft:
+            _emit_error(out, json_out, "AI parsing failed — add manually with --when")
+            return
+        title = draft.title
+        try:
+            day = (
+                parse_due_date(draft.date_phrase) if draft.date_phrase else date.today()
+            )
+        except ValueError:
+            _emit_error(out, json_out, f"Could not understand the date in: {text!r}")
+            return
+
+        if draft.time:
+            try:
+                start_at = datetime.combine(day, parse_datetime(draft.time).time())
+            except ValueError:
+                start_at = datetime.combine(day, dt_time(0, 0))
+                all_day = True
+        else:
+            start_at = datetime.combine(day, dt_time(0, 0))
+            all_day = True
+
+        if draft.end_time:
+            try:
+                end_at = datetime.combine(day, parse_datetime(draft.end_time).time())
+            except ValueError:
+                end_at = None
+        elif draft.duration_minutes:
+            end_at = start_at + timedelta(minutes=draft.duration_minutes)
+
+        location = location or draft.location
+        attendee_tokens = draft.attendees
+
+    if duration and not end_at:
+        end_at = start_at + timedelta(minutes=duration)
+
+    event = event_repo.create_event(
+        title,
+        start_at,
+        end_at=end_at,
+        description=description,
+        location=location,
+        all_day=all_day,
+    )
+
+    emails = contact_repo.resolve(attendee_tokens) if attendee_tokens else []
+    if emails:
+        event_repo.set_attendees(event.id, emails)
+        event.attendees = emails
+
+    if json_out:
+        _emit_json(_event_to_dict(event))
+        return
+
+    console.print(f"[green]✓ Event:[/green] {event.title}")
+    console.print(
+        f"[dim]ID {event.id} · {event.start_at.strftime('%Y-%m-%d %H:%M')}[/dim]"
+    )
+    if event.location:
+        console.print(f"[dim]Where: {event.location}[/dim]")
+    if emails:
+        console.print(f"[dim]Invitees: {', '.join(emails)}[/dim]")
+    console.print("[dim]Local only — Google Calendar sync lands in Phase 2.[/dim]")
+
+
+@event_app.command("ls")
+@event_app.command("list")
+def event_list(
+    all_events: bool = typer.Option(
+        False, "--all", "-a", help="Include past and cancelled events"
+    ),
+    limit: int = typer.Option(20, "--limit", "-l"),
+    json_out: bool = typer.Option(False, "--json", "-j", help="Emit events as JSON"),
+) -> None:
+    """List upcoming events (or all with --all)."""
+    _initialize_services()
+
+    events = event_repo.list_events(
+        upcoming_only=not all_events,
+        include_cancelled=all_events,
+        limit=limit,
+    )
+
+    if json_out:
+        _emit_json({"events": [_event_to_dict(e) for e in events]})
+        return
+
+    if not events:
+        console.print("[yellow]No events found[/yellow]")
+        console.print("[dim]Add one with 'todo event add <text>'[/dim]")
+        return
+
+    table = Table(title="📅 Events", show_header=True, header_style="bold blue")
+    table.add_column("ID", style="cyan", width=3)
+    table.add_column("Event", style="white")
+    table.add_column("When", style="green")
+    table.add_column("Where", style="blue")
+    table.add_column("Invitees", style="magenta")
+    table.add_column("Sync", style="yellow", width=4)
+
+    for event in events:
+        when = (
+            event.start_at.strftime("%Y-%m-%d")
+            if event.all_day
+            else event.start_at.strftime("%Y-%m-%d %H:%M")
+        )
+        title = event.title
+        if event.status.value == "cancelled":
+            title = f"[strike]{title}[/strike]"
+        table.add_row(
+            str(event.id),
+            title,
+            when,
+            event.location or "—",
+            str(len(event.attendees)) if event.attendees else "—",
+            "✓" if event.is_synced else "○",
+        )
+
+    console.print(table)
+
+
+@event_app.command("show")
+def event_show(
+    event_id: int,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Show details for one event."""
+    _initialize_services()
+
+    event = event_repo.get_by_id(event_id)
+    if not event:
+        _emit_error(
+            console_err if json_out else console,
+            json_out,
+            f"Event {event_id} not found",
+        )
+        return
+
+    if json_out:
+        _emit_json(_event_to_dict(event))
+        return
+
+    console.print(f"\n[bold cyan]Event #{event.id}[/bold cyan]")
+    console.print(f"[white]{event.title}[/white]")
+    if event.description:
+        console.print(f"[dim]{event.description}[/dim]")
+    info = Table(show_header=False, show_edge=False, padding=(0, 2))
+    info.add_column("Field", style="cyan", width=12)
+    info.add_column("Value", style="white")
+    when = (
+        event.start_at.strftime("%Y-%m-%d")
+        if event.all_day
+        else event.start_at.strftime("%Y-%m-%d %H:%M")
+    )
+    info.add_row("When", when)
+    if event.end_at:
+        info.add_row("Ends", event.end_at.strftime("%Y-%m-%d %H:%M"))
+    info.add_row("Status", event.status.value.title())
+    if event.location:
+        info.add_row("Where", event.location)
+    if event.attendees:
+        info.add_row("Invitees", ", ".join(event.attendees))
+    info.add_row("Synced", "Yes" if event.is_synced else "No")
+    console.print(info)
+
+
+@event_app.command("cancel")
+def event_cancel(
+    event_id: int,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Mark an event cancelled (kept in history; excluded from the default list)."""
+    _initialize_services()
+
+    event = event_repo.cancel_event(event_id)
+    if not event:
+        _emit_error(
+            console_err if json_out else console,
+            json_out,
+            f"Event {event_id} not found",
+        )
+        return
+
+    if json_out:
+        _emit_json(_event_to_dict(event))
+        return
+    console.print(f"[green]✓ Cancelled event {event_id}:[/green] {event.title}")
+
+
+@event_app.command("delete")
+@event_app.command("rm")
+def event_delete(
+    event_id: int,
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Permanently delete an event (and its attendees). Cannot be undone."""
+    _initialize_services()
+    out = console_err if json_out else console
+
+    if not force:
+        if json_out:
+            _emit_json({"error": "Refusing to delete without --force in --json mode"})
+            return
+        if not typer.confirm(f"Permanently delete event {event_id}?"):
+            console.print("[yellow]Aborted[/yellow]")
+            return
+
+    deleted = event_repo.delete_event(event_id)
+    if json_out:
+        _emit_json({"deleted": event_id if deleted else None, "found": deleted})
+        return
+    if deleted:
+        console.print(f"[green]🗑  Deleted event {event_id}[/green]")
+    else:
+        out.print(f"[red]✗ Event {event_id} not found[/red]")
+
+
+app.add_typer(event_app, name="event")
+
+
+# ---------------------------------------------------------------------------
+# Contacts
+# ---------------------------------------------------------------------------
+contact_app = typer.Typer(help="Contact aliases for event invites")
+
+
+@contact_app.command("add")
+def contact_add(
+    alias: str,
+    emails: list[str] = typer.Argument(..., help="One or more emails for this alias"),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Map an alias to one or more emails (e.g. 'contact add kids a@x.com b@x.com')."""
+    _initialize_services()
+
+    for email in emails:
+        contact_repo.add_contact(alias, email)
+    all_emails = contact_repo.get_emails(alias)
+
+    if json_out:
+        _emit_json({"alias": alias.lower(), "emails": all_emails})
+        return
+    console.print(f"[green]✓ {alias.lower()}[/green] → {', '.join(all_emails)}")
+
+
+@contact_app.command("ls")
+@contact_app.command("list")
+def contact_list(
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List all contact aliases and their emails."""
+    _initialize_services()
+
+    contacts = contact_repo.list_contacts()
+    if json_out:
+        _emit_json({"contacts": contacts})
+        return
+    if not contacts:
+        console.print("[yellow]No contacts[/yellow]")
+        console.print("[dim]Add one with 'todo contact add <alias> <email>'[/dim]")
+        return
+    table = Table(title="👥 Contacts", show_header=True, header_style="bold blue")
+    table.add_column("Alias", style="cyan")
+    table.add_column("Emails", style="white")
+    for alias, emails in contacts.items():
+        table.add_row(alias, ", ".join(emails))
+    console.print(table)
+
+
+@contact_app.command("rm")
+@contact_app.command("delete")
+def contact_remove(
+    alias: str,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Remove an alias and all its email mappings."""
+    _initialize_services()
+
+    removed = contact_repo.remove_alias(alias)
+    if json_out:
+        _emit_json({"alias": alias.lower(), "removed": removed})
+        return
+    if removed:
+        console.print(f"[green]✓ Removed {alias.lower()} ({removed} email(s))[/green]")
+    else:
+        console.print(f"[yellow]No contact alias '{alias.lower()}'[/yellow]")
+
+
+app.add_typer(contact_app, name="contact")
 
 
 @app.command("achievements")

--- a/src/todo/cli/main.py
+++ b/src/todo/cli/main.py
@@ -63,6 +63,10 @@ def _initialize_services():
             )
             migration_manager.run_migrations()
 
+        # Ensure newer tables (events/contacts) exist even on databases that
+        # were initialized before they were added. Idempotent.
+        migration_manager.ensure_events_schema()
+
         todo_repo = TodoRepository(db)
         ai_repo = AIEnrichmentRepository(db)
         enrichment_service = EnrichmentService(db)

--- a/src/todo/core/dates.py
+++ b/src/todo/core/dates.py
@@ -128,3 +128,26 @@ def parse_due_date(text: str, today: date | None = None) -> date:
             parsed = parsed.replace(year=parsed.year + 1)
 
     return parsed
+
+
+def parse_datetime(text: str, now: datetime | None = None) -> datetime:
+    """Parse an explicit date/time string into a :class:`datetime`.
+
+    Used for the event ``--when`` flag (deterministic, no AI). Accepts most
+    formats dateutil understands (``2026-06-12 19:00``, ``june 12 7pm``,
+    ``7pm`` -> today at 19:00). Missing components default to ``now``.
+
+    Raises:
+        ValueError: If the string cannot be parsed.
+    """
+    if now is None:
+        now = datetime.now()
+    # Zero minute/second so an unspecified time ("7pm") doesn't inherit them
+    # from "now"; an explicitly given minute ("9:30") is still respected.
+    now = now.replace(minute=0, second=0, microsecond=0)
+    if not text or not text.strip():
+        raise ValueError("Empty date/time expression")
+    try:
+        return _dateutil_parser.parse(text.strip(), default=now)
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(f"Could not parse date/time: {text!r}") from exc

--- a/src/todo/db/migrations.py
+++ b/src/todo/db/migrations.py
@@ -93,6 +93,68 @@ class MigrationManager:
             print(f"❌ Error recording initial migration: {e}")
             raise
 
+    # Statements mirror the events/contacts section of schema.sql. Kept here so
+    # already-initialized databases (which the legacy runner never re-touches)
+    # also get the tables. All idempotent (CREATE ... IF NOT EXISTS).
+    _EVENTS_DDL = [
+        "CREATE SEQUENCE IF NOT EXISTS events_id_seq",
+        """CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY DEFAULT nextval('events_id_seq'),
+            uuid VARCHAR(36) NOT NULL UNIQUE,
+            title VARCHAR(500) NOT NULL,
+            description VARCHAR(2000),
+            start_at TIMESTAMP NOT NULL,
+            end_at TIMESTAMP,
+            all_day BOOLEAN DEFAULT FALSE,
+            location VARCHAR(500),
+            status VARCHAR(20) NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'cancelled')),
+            google_event_id VARCHAR(255),
+            google_calendar_id VARCHAR(255),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_events_start ON events(start_at)",
+        "CREATE INDEX IF NOT EXISTS idx_events_status ON events(status)",
+        "CREATE SEQUENCE IF NOT EXISTS contacts_id_seq",
+        """CREATE TABLE IF NOT EXISTS contacts (
+            id INTEGER PRIMARY KEY DEFAULT nextval('contacts_id_seq'),
+            alias VARCHAR(50) NOT NULL,
+            email VARCHAR(254) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (alias, email)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_contacts_alias ON contacts(alias)",
+        "CREATE SEQUENCE IF NOT EXISTS event_attendees_id_seq",
+        # No hard FK on event_id: DuckDB rejects UPDATEs on a referenced parent.
+        """CREATE TABLE IF NOT EXISTS event_attendees (
+            id INTEGER PRIMARY KEY DEFAULT nextval('event_attendees_id_seq'),
+            event_id INTEGER NOT NULL,
+            email VARCHAR(254) NOT NULL,
+            response_status VARCHAR(20) DEFAULT 'needsAction',
+            UNIQUE (event_id, email)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_event_attendees_event ON event_attendees(event_id)",
+    ]
+
+    def ensure_events_schema(self) -> None:
+        """Ensure the events/contacts tables exist (migration v3).
+
+        Idempotent and safe to call on every startup — covers databases that
+        were initialized before these tables existed.
+        """
+        conn = self.db.connect()
+        for stmt in self._EVENTS_DDL:
+            conn.execute(stmt)
+        if self.get_current_version() < 3:
+            self._ensure_migration_table()
+            conn.execute(
+                """
+                INSERT INTO schema_migrations (version, name)
+                VALUES (3, 'events_and_contacts')
+                ON CONFLICT(version) DO NOTHING
+                """
+            )
+
     def run_migrations(self) -> None:
         """Run all pending migrations."""
         if not self.is_schema_initialized():

--- a/src/todo/db/repository.py
+++ b/src/todo/db/repository.py
@@ -2,7 +2,7 @@
 
 import json
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import date, datetime
 from typing import Any, TypeVar
 from uuid import uuid4
 
@@ -12,7 +12,10 @@ from ..models import (
     AILearningFeedback,
     AIProvider,
     Category,
+    Contact,
     DailyActivity,
+    Event,
+    EventStatus,
     Priority,
     TaskSize,
     Todo,
@@ -1103,3 +1106,182 @@ class AILearningFeedbackRepository(BaseRepository[AILearningFeedback]):
         )
         results = cursor.fetchall()
         return [self._row_to_model(_row_to_dict(row, cursor)) for row in results]
+
+
+class EventRepository(BaseRepository[Event]):
+    """Repository for calendar Event operations."""
+
+    def _get_table_name(self) -> str:
+        return "events"
+
+    def _row_to_model(self, row: dict[str, Any]) -> Event:
+        if row.get("status"):
+            row["status"] = EventStatus(row["status"])
+        return Event(**row)
+
+    def create_event(
+        self,
+        title: str,
+        start_at: datetime,
+        *,
+        end_at: datetime | None = None,
+        description: str | None = None,
+        location: str | None = None,
+        all_day: bool = False,
+    ) -> Event:
+        """Create a new event and return it (with empty attendee list)."""
+        conn = self.db.connect()
+        cursor = conn.execute(
+            """
+            INSERT INTO events
+                (uuid, title, description, start_at, end_at, all_day, location)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            RETURNING *
+            """,
+            [str(uuid4()), title, description, start_at, end_at, all_day, location],
+        )
+        event = self._row_to_model(_row_to_dict(cursor.fetchone(), cursor))
+        event.attendees = self.get_attendees(event.id)
+        return event
+
+    def get_by_id(self, record_id: int) -> Event | None:
+        """Get an event by id, with its attendees populated."""
+        event = super().get_by_id(record_id)
+        if event:
+            event.attendees = self.get_attendees(record_id)
+        return event
+
+    def list_events(
+        self,
+        *,
+        upcoming_only: bool = True,
+        include_cancelled: bool = False,
+        limit: int | None = None,
+    ) -> list[Event]:
+        """List events ordered by start time, with attendees populated."""
+        conn = self.db.connect()
+        clauses: list[str] = []
+        if not include_cancelled:
+            clauses.append("status != 'cancelled'")
+        if upcoming_only:
+            clauses.append("start_at >= CURRENT_TIMESTAMP")
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        query = f"SELECT * FROM events {where} ORDER BY start_at ASC"
+        params: list[Any] = []
+        if limit:
+            query += " LIMIT ?"
+            params.append(limit)
+
+        cursor = conn.execute(query, params)
+        rows = cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+        events = [self._row_to_model(dict(zip(cols, r))) for r in rows]
+        for event in events:
+            event.attendees = self.get_attendees(event.id)
+        return events
+
+    def cancel_event(self, event_id: int) -> Event | None:
+        """Mark an event cancelled. Returns None if it does not exist."""
+        conn = self.db.connect()
+        if super().get_by_id(event_id) is None:
+            return None
+        conn.execute(
+            "UPDATE events SET status = 'cancelled', "
+            "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            [event_id],
+        )
+        return self.get_by_id(event_id)
+
+    def delete_event(self, event_id: int) -> bool:
+        """Permanently delete an event and its attendees."""
+        conn = self.db.connect()
+        if super().get_by_id(event_id) is None:
+            return False
+        conn.execute("DELETE FROM event_attendees WHERE event_id = ?", [event_id])
+        conn.execute("DELETE FROM events WHERE id = ?", [event_id])
+        return super().get_by_id(event_id) is None
+
+    def set_attendees(self, event_id: int, emails: list[str]) -> None:
+        """Replace the attendee list for an event (deduped, order preserved)."""
+        conn = self.db.connect()
+        conn.execute("DELETE FROM event_attendees WHERE event_id = ?", [event_id])
+        for email in dict.fromkeys(emails):
+            conn.execute(
+                "INSERT INTO event_attendees (event_id, email) VALUES (?, ?) "
+                "ON CONFLICT DO NOTHING",
+                [event_id, email],
+            )
+
+    def get_attendees(self, event_id: int) -> list[str]:
+        """Return the attendee emails for an event."""
+        conn = self.db.connect()
+        rows = conn.execute(
+            "SELECT email FROM event_attendees WHERE event_id = ? ORDER BY email",
+            [event_id],
+        ).fetchall()
+        return [r[0] for r in rows]
+
+
+class ContactRepository(BaseRepository[Contact]):
+    """Repository for contact-alias operations."""
+
+    def _get_table_name(self) -> str:
+        return "contacts"
+
+    def _row_to_model(self, row: dict[str, Any]) -> Contact:
+        return Contact(**row)
+
+    def add_contact(self, alias: str, email: str) -> Contact:
+        """Add an (alias, email) mapping. No-op if it already exists."""
+        conn = self.db.connect()
+        conn.execute(
+            "INSERT INTO contacts (alias, email) VALUES (?, ?) "
+            "ON CONFLICT (alias, email) DO NOTHING",
+            [alias.lower(), email],
+        )
+        return Contact(alias=alias.lower(), email=email)
+
+    def get_emails(self, alias: str) -> list[str]:
+        """Return all emails mapped to an alias."""
+        conn = self.db.connect()
+        rows = conn.execute(
+            "SELECT email FROM contacts WHERE alias = ? ORDER BY email",
+            [alias.lower()],
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def list_contacts(self) -> dict[str, list[str]]:
+        """Return all aliases mapped to their email lists."""
+        conn = self.db.connect()
+        rows = conn.execute(
+            "SELECT alias, email FROM contacts ORDER BY alias, email"
+        ).fetchall()
+        out: dict[str, list[str]] = {}
+        for alias, email in rows:
+            out.setdefault(alias, []).append(email)
+        return out
+
+    def remove_alias(self, alias: str) -> int:
+        """Delete all mappings for an alias. Returns how many were removed."""
+        conn = self.db.connect()
+        count = len(self.get_emails(alias))
+        if count:
+            conn.execute("DELETE FROM contacts WHERE alias = ?", [alias.lower()])
+        return count
+
+    def resolve(self, tokens: list[str]) -> list[str]:
+        """Resolve a mix of aliases and raw emails to a deduped email list.
+
+        A token containing '@' is treated as a literal email; otherwise it is
+        looked up as an alias (unknown aliases contribute nothing).
+        """
+        emails: list[str] = []
+        for raw in tokens:
+            token = raw.strip()
+            if not token:
+                continue
+            if "@" in token:
+                emails.append(token)
+            else:
+                emails.extend(self.get_emails(token))
+        return list(dict.fromkeys(emails))

--- a/src/todo/db/schema.sql
+++ b/src/todo/db/schema.sql
@@ -253,6 +253,50 @@ INSERT INTO achievements (name, description, icon, requirement_type, requirement
 ('Point Master', 'Earn 5000 points', '💍', 'points_earned', 5000, 500)
 ON CONFLICT(name) DO NOTHING;
 
+-- Events (calendar events, optionally synced to Google Calendar)
+CREATE SEQUENCE IF NOT EXISTS events_id_seq;
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY DEFAULT nextval('events_id_seq'),
+    uuid VARCHAR(36) NOT NULL UNIQUE,
+    title VARCHAR(500) NOT NULL,
+    description VARCHAR(2000),
+    start_at TIMESTAMP NOT NULL,
+    end_at TIMESTAMP,
+    all_day BOOLEAN DEFAULT FALSE,
+    location VARCHAR(500),
+    status VARCHAR(20) NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'cancelled')),
+    google_event_id VARCHAR(255),
+    google_calendar_id VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_events_start ON events(start_at);
+CREATE INDEX IF NOT EXISTS idx_events_status ON events(status);
+
+-- Contacts (named aliases to emails, one row per email so "kids" maps to many)
+CREATE SEQUENCE IF NOT EXISTS contacts_id_seq;
+CREATE TABLE IF NOT EXISTS contacts (
+    id INTEGER PRIMARY KEY DEFAULT nextval('contacts_id_seq'),
+    alias VARCHAR(50) NOT NULL,
+    email VARCHAR(254) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (alias, email)
+);
+CREATE INDEX IF NOT EXISTS idx_contacts_alias ON contacts(alias);
+
+-- Event attendees (resolved emails invited to an event)
+CREATE SEQUENCE IF NOT EXISTS event_attendees_id_seq;
+-- No hard FK on event_id: DuckDB rejects UPDATEs on a referenced parent row
+-- (same limitation that drove the v2 migration). Integrity is managed in code.
+CREATE TABLE IF NOT EXISTS event_attendees (
+    id INTEGER PRIMARY KEY DEFAULT nextval('event_attendees_id_seq'),
+    event_id INTEGER NOT NULL,
+    email VARCHAR(254) NOT NULL,
+    response_status VARCHAR(20) DEFAULT 'needsAction',
+    UNIQUE (event_id, email)
+);
+CREATE INDEX IF NOT EXISTS idx_event_attendees_event ON event_attendees(event_id);
+
 -- Schema migrations tracking table
 CREATE TABLE IF NOT EXISTS schema_migrations (
     version INTEGER PRIMARY KEY,

--- a/src/todo/models.py
+++ b/src/todo/models.py
@@ -373,3 +373,53 @@ class StatsResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class EventStatus(str, Enum):
+    """Status of a calendar event."""
+
+    SCHEDULED = "scheduled"
+    CANCELLED = "cancelled"
+
+
+class Contact(BaseModel):
+    """A named contact alias mapped to an email address.
+
+    One row per (alias, email) so an alias like "kids" can map to several
+    emails. Resolution to a set of emails is done by the repository.
+    """
+
+    alias: str = Field(..., min_length=1, max_length=50)
+    email: str = Field(..., min_length=3, max_length=254)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Event(BaseModel):
+    """A calendar event, optionally synced to Google Calendar."""
+
+    id: int | None = None
+    uuid: str = Field(default_factory=lambda: str(uuid4()))
+    title: str = Field(..., min_length=1, max_length=500)
+    description: str | None = Field(None, max_length=2000)
+
+    start_at: datetime
+    end_at: datetime | None = None
+    all_day: bool = False
+    location: str | None = Field(None, max_length=500)
+
+    status: EventStatus = EventStatus.SCHEDULED
+
+    # Google Calendar sync (populated once pushed)
+    google_event_id: str | None = None
+    google_calendar_id: str | None = None
+
+    # Attendee emails — populated by DB queries, not a column on `events`.
+    attendees: list[str] = Field(default_factory=list)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    @property
+    def is_synced(self) -> bool:
+        """Whether this event has been pushed to Google Calendar."""
+        return self.google_event_id is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 import json
 import tempfile
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -994,3 +994,240 @@ class TestCLIDue:
         payload = json.loads(result.stdout.strip())
         assert "error" in payload
         mock_todo_repo.update_todo.assert_not_called()
+
+
+def _make_mock_event(event_id=1, title="Soccer", start=None, attendees=None):
+    """Build a Mock Event with the attributes the serializer reads."""
+    ev = Mock()
+    ev.id = event_id
+    ev.title = title
+    ev.description = None
+    ev.start_at = start or datetime(2026, 6, 13, 10, 0)
+    ev.end_at = None
+    ev.all_day = False
+    ev.location = None
+    ev.status = Mock()
+    ev.status.value = "scheduled"
+    ev.attendees = attendees or []
+    ev.google_event_id = None
+    ev.is_synced = False
+    ev.created_at = datetime(2026, 6, 10, 12, 0)
+    return ev
+
+
+class TestCLIEvents:
+    """Tests for the event sub-app."""
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    def test_event_add_flag_mode(
+        self, mock_contacts, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        """event add --no-ai --when creates an event from flags."""
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.resolve.return_value = []
+        ev = _make_mock_event()
+        mock_events.create_event.return_value = ev
+        mock_events.get_attendees.return_value = []
+
+        result = runner.invoke(
+            app,
+            [
+                "event",
+                "add",
+                "Soccer",
+                "--when",
+                "2026-06-13 10:00",
+                "--no-ai",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["title"] == "Soccer"
+        assert payload["start_at"].startswith("2026-06-13 10:00")
+        # parsed start passed to create_event
+        assert mock_events.create_event.call_args.args[1] == datetime(
+            2026, 6, 13, 10, 0
+        )
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    def test_event_add_flag_requires_when(
+        self, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        """--no-ai without --when errors and creates nothing."""
+        mock_mig.is_schema_initialized.return_value = True
+
+        result = runner.invoke(app, ["event", "add", "Soccer", "--no-ai", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())
+        mock_events.create_event.assert_not_called()
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.event_parser")
+    @patch("todo.cli.main.asyncio.run")
+    def test_event_add_ai_resolves_date(
+        self,
+        mock_run,
+        mock_parser,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        """AI mode resolves the date phrase deterministically (not via the model)."""
+        from todo.ai.event_parser import EventDraft
+
+        mock_mig.is_schema_initialized.return_value = True
+        mock_run.return_value = EventDraft(
+            title="Dinner",
+            date_phrase="friday",
+            time="7pm",
+            attendees=["wife"],
+        )
+        mock_contacts.resolve.return_value = ["jane@example.com"]
+        mock_events.create_event.return_value = _make_mock_event(
+            title="Dinner",
+            start=datetime(2026, 6, 12, 19, 0),
+            attendees=["jane@example.com"],
+        )
+
+        result = runner.invoke(
+            app, ["event", "add", "dinner friday 7pm with wife", "--json"]
+        )
+
+        assert result.exit_code == 0
+        # create_event got a real datetime; the date came from core.dates, not the model
+        start_arg = mock_events.create_event.call_args.args[1]
+        assert isinstance(start_arg, datetime)
+        assert start_arg.hour == 19
+        mock_events.set_attendees.assert_called_once()
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    def test_event_list_json(self, mock_events, mock_mig, mock_db, mock_config, runner):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_events.list_events.return_value = [_make_mock_event()]
+
+        result = runner.invoke(app, ["event", "ls", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["events"][0]["title"] == "Soccer"
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    def test_event_show_not_found(
+        self, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_events.get_by_id.return_value = None
+
+        result = runner.invoke(app, ["event", "show", "99", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    def test_event_delete_requires_force_in_json(
+        self, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+
+        result = runner.invoke(app, ["event", "delete", "1", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())
+        mock_events.delete_event.assert_not_called()
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    def test_event_cancel_json(
+        self, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        ev = _make_mock_event()
+        ev.status.value = "cancelled"
+        mock_events.cancel_event.return_value = ev
+
+        result = runner.invoke(app, ["event", "cancel", "1", "--json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout.strip())["status"] == "cancelled"
+
+
+class TestCLIContacts:
+    """Tests for the contact sub-app."""
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.contact_repo")
+    def test_contact_add_json(
+        self, mock_contacts, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.get_emails.return_value = ["a@x.com", "b@x.com"]
+
+        result = runner.invoke(
+            app, ["contact", "add", "kids", "a@x.com", "b@x.com", "--json"]
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["alias"] == "kids"
+        assert payload["emails"] == ["a@x.com", "b@x.com"]
+        assert mock_contacts.add_contact.call_count == 2
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.contact_repo")
+    def test_contact_list_json(
+        self, mock_contacts, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.list_contacts.return_value = {"wife": ["jane@x.com"]}
+
+        result = runner.invoke(app, ["contact", "ls", "--json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout.strip())["contacts"] == {"wife": ["jane@x.com"]}
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.contact_repo")
+    def test_contact_rm_json(
+        self, mock_contacts, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.remove_alias.return_value = 2
+
+        result = runner.invoke(app, ["contact", "rm", "kids", "--json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout.strip())["removed"] == 2

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,10 +1,10 @@
 """Tests for natural-language due-date parsing."""
 
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
-from todo.core.dates import parse_due_date
+from todo.core.dates import parse_datetime, parse_due_date
 
 # Reference "today": Wednesday, 2026-06-10.
 TODAY = date(2026, 6, 10)
@@ -54,3 +54,18 @@ def test_explicit_year_not_rolled_forward():
 def test_defaults_to_real_today():
     # Smoke check that today=None path works (uses date.today()).
     assert isinstance(parse_due_date("today"), date)
+
+
+def test_parse_datetime_explicit():
+    now = datetime(2026, 6, 10, 15, 27, 45)
+    assert parse_datetime("2026-06-15 14:30", now) == datetime(2026, 6, 15, 14, 30)
+    # bare time inherits the date but zeroes unspecified minute/second
+    assert parse_datetime("7pm", now) == datetime(2026, 6, 10, 19, 0)
+    # explicitly given minute is respected
+    assert parse_datetime("9:30am", now) == datetime(2026, 6, 10, 9, 30)
+
+
+@pytest.mark.parametrize("expr", ["", "   ", "zzzznotadate"])
+def test_parse_datetime_invalid(expr):
+    with pytest.raises(ValueError):
+        parse_datetime(expr, datetime(2026, 6, 10))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,144 @@
+"""Tests for the events + contacts data layer."""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from todo.db.connection import DatabaseConnection
+from todo.db.migrations import MigrationManager
+from todo.db.repository import ContactRepository, EventRepository
+from todo.models import EventStatus
+
+
+@pytest.fixture
+def db():
+    """Temp database with schema + events tables initialized."""
+    tmp = tempfile.mkdtemp()
+    path = Path(tmp) / "events.db"
+    conn = DatabaseConnection(str(path))
+    mm = MigrationManager(conn)
+    mm.initialize_schema()
+    mm.ensure_events_schema()
+    yield conn
+    conn.close()
+    if path.exists():
+        path.unlink()
+    Path(tmp).rmdir()
+
+
+@pytest.fixture
+def events(db):
+    return EventRepository(db)
+
+
+@pytest.fixture
+def contacts(db):
+    return ContactRepository(db)
+
+
+class TestContactRepository:
+    def test_add_and_get(self, contacts):
+        contacts.add_contact("Wife", "jane@example.com")  # alias lowercased
+        assert contacts.get_emails("wife") == ["jane@example.com"]
+
+    def test_multi_email_alias(self, contacts):
+        contacts.add_contact("kids", "sam@example.com")
+        contacts.add_contact("kids", "alex@example.com")
+        assert contacts.get_emails("kids") == ["alex@example.com", "sam@example.com"]
+
+    def test_add_is_idempotent(self, contacts):
+        contacts.add_contact("wife", "jane@example.com")
+        contacts.add_contact("wife", "jane@example.com")
+        assert contacts.get_emails("wife") == ["jane@example.com"]
+
+    def test_list_contacts(self, contacts):
+        contacts.add_contact("wife", "jane@example.com")
+        contacts.add_contact("kids", "sam@example.com")
+        assert contacts.list_contacts() == {
+            "kids": ["sam@example.com"],
+            "wife": ["jane@example.com"],
+        }
+
+    def test_resolve_mixes_aliases_and_emails_and_dedupes(self, contacts):
+        contacts.add_contact("wife", "jane@example.com")
+        contacts.add_contact("kids", "sam@example.com")
+        contacts.add_contact("kids", "alex@example.com")
+        resolved = contacts.resolve(
+            ["wife", "kids", "extra@x.com", "jane@example.com", "unknown"]
+        )
+        # jane appears via alias and literal -> deduped; unknown alias -> nothing
+        assert resolved == [
+            "jane@example.com",
+            "alex@example.com",
+            "sam@example.com",
+            "extra@x.com",
+        ]
+
+    def test_remove_alias(self, contacts):
+        contacts.add_contact("kids", "sam@example.com")
+        contacts.add_contact("kids", "alex@example.com")
+        assert contacts.remove_alias("kids") == 2
+        assert contacts.get_emails("kids") == []
+        assert contacts.remove_alias("kids") == 0
+
+
+class TestEventRepository:
+    def test_create_and_get(self, events):
+        ev = events.create_event(
+            "Dinner",
+            datetime(2026, 6, 12, 19, 0),
+            location="Home",
+            description="bring wine",
+        )
+        assert ev.id is not None
+        fetched = events.get_by_id(ev.id)
+        assert fetched.title == "Dinner"
+        assert fetched.location == "Home"
+        assert fetched.status == EventStatus.SCHEDULED
+        assert fetched.is_synced is False
+        assert fetched.attendees == []
+
+    def test_attendees_roundtrip_and_dedup(self, events):
+        ev = events.create_event("Party", datetime(2026, 6, 12, 19, 0))
+        events.set_attendees(ev.id, ["a@x.com", "b@x.com", "a@x.com"])
+        assert events.get_by_id(ev.id).attendees == ["a@x.com", "b@x.com"]
+        # set replaces
+        events.set_attendees(ev.id, ["c@x.com"])
+        assert events.get_by_id(ev.id).attendees == ["c@x.com"]
+
+    def test_list_upcoming_excludes_past_and_cancelled(self, events):
+        events.create_event("Past", datetime(2020, 1, 1, 9, 0))
+        events.create_event("Future", datetime(2099, 1, 1, 9, 0))
+        cancelled = events.create_event("Cancelled", datetime(2099, 1, 2, 9, 0))
+        events.cancel_event(cancelled.id)
+
+        upcoming = events.list_events()
+        titles = [e.title for e in upcoming]
+        assert "Future" in titles
+        assert "Past" not in titles
+        assert "Cancelled" not in titles
+
+        all_events = events.list_events(upcoming_only=False, include_cancelled=True)
+        assert {"Past", "Future", "Cancelled"} <= {e.title for e in all_events}
+
+    def test_cancel(self, events):
+        ev = events.create_event("Meeting", datetime(2099, 1, 1, 9, 0))
+        events.set_attendees(ev.id, ["a@x.com"])  # cancel works despite attendees
+        cancelled = events.cancel_event(ev.id)
+        assert cancelled.status == EventStatus.CANCELLED
+        assert events.cancel_event(99999) is None
+
+    def test_delete_removes_attendees(self, events, db):
+        ev = events.create_event("Gone", datetime(2099, 1, 1, 9, 0))
+        events.set_attendees(ev.id, ["a@x.com", "b@x.com"])
+        assert events.delete_event(ev.id) is True
+        assert events.get_by_id(ev.id) is None
+        remaining = (
+            db.connect()
+            .execute("SELECT COUNT(*) FROM event_attendees WHERE event_id = ?", [ev.id])
+            .fetchone()[0]
+        )
+        assert remaining == 0
+        assert events.delete_event(ev.id) is False


### PR DESCRIPTION
Phase 1 of the events feature (epic SB-124). Local-only — no Google Calendar yet.

## What
- **Data layer:** `Event`/`Contact`/`EventStatus` models; `events`, `contacts`, `event_attendees` tables (schema.sql + idempotent v3 `ensure_events_schema()` so existing DBs get them — the legacy runner only touches uninitialized DBs); `EventRepository` + `ContactRepository`.
- **AI parsing:** `event_parser.py` extracts event fields and **raw date/time phrases** (not absolute dates — small models flub weekday math). The CLI resolves the date deterministically via `core.dates` and combines with the parsed time.
- **CLI:** `todo event add` (AI mode + `--when` flag mode), `event ls/show/cancel/delete`, `todo contact add/ls/rm`. All `--json`. Invitees resolved through contact aliases (`wife`, `kids`).

## Notable decisions
- `event_attendees` has **no hard FK** on `event_id`: DuckDB rejects UPDATEs on a referenced parent row (same limitation behind the v2 migration). Integrity managed in code.
- `parse_datetime` zeroes unspecified minute/second so `7pm` → `19:00`, while `9:30` is respected.

## Verified
- AI: "dinner with parents friday 7pm at their place, invite wife and kids" → 2026-06-12 19:00, location, wife+kids emails resolved. (Earlier the model alone put "friday" on the wrong day; deterministic resolution fixed it.)
- Tests: repo tests, `parse_datetime` tests, CLI tests for event/contact incl. the AI date-resolution path. Pre-existing failures (goals/analytics/cli_runtime/achievement-e2e global-`db` isolation) are unrelated.

## Not in this PR (later phases)
Google Calendar push + OAuth (SB-126), invites (SB-127), two-way pull (SB-128).

Fixes SB-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)