### PR TITLE
Add completion note to done (todo done --note)

### DIFF
--- a/src/todo/cli/main.py
+++ b/src/todo/cli/main.py
@@ -63,6 +63,10 @@ def _initialize_services():
             )
             migration_manager.run_migrations()
 
+        # Ensure newer columns exist even on databases initialized before they
+        # were added. Idempotent.
+        migration_manager.ensure_completion_note()
+
         todo_repo = TodoRepository(db)
         ai_repo = AIEnrichmentRepository(db)
         enrichment_service = EnrichmentService(db)
@@ -134,6 +138,7 @@ def _todo_to_dict(todo: Any, ai_enrichment: Any = None) -> dict[str, Any]:
         "is_overdue": todo.is_overdue,
         "created_at": todo.created_at,
         "completed_at": todo.completed_at,
+        "completion_note": todo.completion_note,
         "ai_enriched": ai_enrichment is not None,
     }
 
@@ -454,6 +459,9 @@ def complete_todo(
     todo_ids: list[int] = typer.Argument(
         ..., help="One or more todo IDs to mark as completed"
     ),
+    note: str | None = typer.Option(
+        None, "--note", "-n", help="Completion note (applied to each todo)"
+    ),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Emit result as JSON (machine-readable)"
     ),
@@ -479,7 +487,7 @@ def complete_todo(
 
     for todo_id in todo_ids:
         try:
-            todo = todo_repo.complete_todo(todo_id)
+            todo = todo_repo.complete_todo(todo_id, note=note)
 
             if todo:
                 completed_count += 1
@@ -784,6 +792,9 @@ def show_todo(
 
     if todo.completed_at:
         info_table.add_row("Completed", todo.completed_at.strftime("%Y-%m-%d %H:%M"))
+
+    if todo.completion_note:
+        info_table.add_row("Note", todo.completion_note)
 
     if todo.total_points_earned:
         info_table.add_row("Points", str(todo.total_points_earned))

--- a/src/todo/db/migrations.py
+++ b/src/todo/db/migrations.py
@@ -93,6 +93,23 @@ class MigrationManager:
             print(f"❌ Error recording initial migration: {e}")
             raise
 
+    def ensure_completion_note(self) -> None:
+        """Ensure the todos.completion_note column exists (migration v4).
+
+        Idempotent and safe to call on every startup.
+        """
+        conn = self.db.connect()
+        conn.execute("ALTER TABLE todos ADD COLUMN IF NOT EXISTS completion_note TEXT")
+        if self.get_current_version() < 4:
+            self._ensure_migration_table()
+            conn.execute(
+                """
+                INSERT INTO schema_migrations (version, name)
+                VALUES (4, 'todo_completion_note')
+                ON CONFLICT(version) DO NOTHING
+                """
+            )
+
     def run_migrations(self) -> None:
         """Run all pending migrations."""
         if not self.is_schema_initialized():

--- a/src/todo/db/repository.py
+++ b/src/todo/db/repository.py
@@ -313,11 +313,12 @@ class TodoRepository(BaseRepository[Todo]):
         column_names = [desc[0] for desc in cursor.description]
         return [self._row_to_model(dict(zip(column_names, row))) for row in results]
 
-    def complete_todo(self, todo_id: int) -> Todo | None:
+    def complete_todo(self, todo_id: int, note: str | None = None) -> Todo | None:
         """Mark todo as completed and calculate points using the scoring system.
 
         Args:
             todo_id: ID of the todo to complete.
+            note: Optional completion note stored on the todo.
 
         Returns:
             Updated todo if successful, None otherwise.
@@ -348,13 +349,14 @@ class TodoRepository(BaseRepository[Todo]):
                 UPDATE todos
                 SET status = 'completed',
                     completed_at = CURRENT_TIMESTAMP,
+                    completion_note = ?,
                     base_points = ?,
                     bonus_points = ?,
                     total_points_earned = ?,
                     updated_at = CURRENT_TIMESTAMP
                 WHERE id = ?
             """,
-                [base_points, bonus_points, total_points, todo_id],
+                [note, base_points, bonus_points, total_points, todo_id],
             )
 
             if result.rowcount == 0:

--- a/src/todo/db/schema.sql
+++ b/src/todo/db/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS todos (
     actual_minutes INTEGER CHECK (actual_minutes > 0),
     started_at TIMESTAMP,
     completed_at TIMESTAMP,
+    completion_note TEXT,
     due_date DATE,
 
     -- Gamification

--- a/src/todo/models.py
+++ b/src/todo/models.py
@@ -108,6 +108,7 @@ class Todo(BaseModel):
     actual_minutes: int | None = Field(None, ge=1)
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    completion_note: str | None = Field(None, max_length=2000)
     due_date: date | None = None
 
     # Recurrence

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,7 @@ class TestCLICommands:
         assert result.exit_code == 0
         assert "✓ Completed: Test task" in result.stdout
         assert "🎉 Earned 5 points!" in result.stdout
-        mock_todo_repo.complete_todo.assert_called_once_with(1)
+        mock_todo_repo.complete_todo.assert_called_once_with(1, note=None)
 
     @patch("todo.cli.main.config")
     @patch("todo.cli.main.db")
@@ -269,6 +269,7 @@ class TestCLICommands:
         mock_todo.created_at = Mock()
         mock_todo.created_at.strftime = Mock(return_value="2025-01-01 12:00")
         mock_todo.completed_at = None
+        mock_todo.completion_note = None
         mock_todo.total_points_earned = None
 
         mock_todo_repo.get_by_id.return_value = mock_todo
@@ -545,6 +546,7 @@ class TestCLIIntegration:
         mock_todo.created_at = Mock()
         mock_todo.created_at.strftime = Mock(return_value="2025-01-01 12:00")
         mock_todo.completed_at = None
+        mock_todo.completion_note = None
         mock_todo.total_points_earned = None
 
         mock_enrichment = Mock()
@@ -595,6 +597,7 @@ def _make_mock_todo(
     todo.is_overdue = False
     todo.created_at = "2026-01-01 00:00:00"
     todo.completed_at = None
+    todo.completion_note = None
     return todo
 
 
@@ -745,7 +748,7 @@ class TestCLIJsonOutput:
         completed.total_points_earned = 0
         # id 1 completes, id 2 returns None (not found / already done)
         mock_todo_repo.complete_todo.side_effect = (
-            lambda tid: completed if tid == 1 else None
+            lambda tid, note=None: completed if tid == 1 else None
         )
 
         result = runner.invoke(app, ["done", "1", "2", "--json"])
@@ -994,3 +997,30 @@ class TestCLIDue:
         payload = json.loads(result.stdout.strip())
         assert "error" in payload
         mock_todo_repo.update_todo.assert_not_called()
+
+
+class TestCLIDoneNote:
+    """Tests for completing a todo with a note."""
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.todo_repo")
+    def test_done_with_note(
+        self, mock_todo_repo, mock_migration, mock_db, mock_config, runner
+    ):
+        """done --note passes the note through to complete_todo."""
+        mock_migration.is_schema_initialized.return_value = True
+        completed = _make_mock_todo()
+        completed.scoring_result = None
+        completed.total_points_earned = 0
+        mock_todo_repo.complete_todo.return_value = completed
+
+        result = runner.invoke(
+            app, ["done", "1", "--note", "paid via portal #8891", "--json"]
+        )
+
+        assert result.exit_code == 0
+        mock_todo_repo.complete_todo.assert_called_once_with(
+            1, note="paid via portal #8891"
+        )

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -325,3 +325,17 @@ class TestRepositoryBase:
         )
         completed_large = todo_repo.complete_todo(large_todo.id)
         assert completed_large.base_points == 5
+
+
+class TestCompletionNote:
+    """Completion note on complete_todo."""
+
+    def test_complete_with_note_stored(self, todo_repo):
+        todo = todo_repo.create_todo("Pay bills")
+        todo_repo.complete_todo(todo.id, note="paid $240, conf #8891")
+        assert todo_repo.get_by_id(todo.id).completion_note == "paid $240, conf #8891"
+
+    def test_complete_without_note_is_none(self, todo_repo):
+        todo = todo_repo.create_todo("Other")
+        todo_repo.complete_todo(todo.id)
+        assert todo_repo.get_by_id(todo.id).completion_note is None


### PR DESCRIPTION
## What
Attach a note when completing a todo:
```bash
todo done 154 --note "paid $240 via portal, conf #8891"
```

## Changes
- **schema:** `completion_note` column on `todos`.
- **migration:** `ensure_completion_note()` (v4) — idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS`, run on every startup so existing DBs gain the column (the legacy runner only touches uninitialized DBs).
- **model/repo:** `Todo.completion_note`; `complete_todo(todo_id, note=None)`.
- **cli:** `done`/`complete` gains `--note/-n` (applied to each id); surfaced in `todo show` and `--json`.

## Verified
Live on the real DB (proves the ALTER runs on an existing DB): added → done with note → `show` displays it. Repo + CLI tests added; full suite back to the pre-existing baseline (17 failures, all unrelated goals/analytics/cli_runtime/achievement-e2e isolation).

Note: independent of the open Events PR (#10) — different code paths, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)