### PR TITLE
Events Phase 2: Google Calendar push + OAuth (SB-126)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "click>=8.1.7",  # Required by typer
     "python-dateutil>=2.9.0.post0",
+    "gcsa>=2.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/todo/cli/main.py
+++ b/src/todo/cli/main.py
@@ -1,6 +1,7 @@
 """Main CLI application entry point."""
 
 import asyncio
+import contextlib
 import json
 from datetime import date, datetime, timedelta
 from datetime import time as dt_time
@@ -23,6 +24,7 @@ from ..db.repository import (
     EventRepository,
     TodoRepository,
 )
+from ..gcal.client import CalendarAuthError, GoogleCalendarClient
 from ..models import AIProvider
 
 console = Console()
@@ -46,6 +48,7 @@ background_service = None
 event_repo = None
 contact_repo = None
 event_parser = None
+gcal_client = None
 
 
 def _initialize_services():
@@ -60,7 +63,8 @@ def _initialize_services():
         background_service, \
         event_repo, \
         contact_repo, \
-        event_parser
+        event_parser, \
+        gcal_client
 
     if db is not None:
         return  # Already initialized
@@ -89,6 +93,7 @@ def _initialize_services():
         event_repo = EventRepository(db)
         contact_repo = ContactRepository(db)
         event_parser = EventParser()
+        gcal_client = GoogleCalendarClient(config.calendar)
     except RuntimeError as e:
         # Handle database lock errors gracefully
         console.print(f"[red]✗ Database Error:[/red] {e}")
@@ -177,6 +182,31 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
         "is_synced": event.is_synced,
         "created_at": event.created_at,
     }
+
+
+def _push_event_to_google(event: Any) -> str | None:
+    """Push an event to Google Calendar and persist its id.
+
+    Returns None on success, or an error message string on failure.
+    """
+    try:
+        gid = gcal_client.push_event(event)
+    except CalendarAuthError as e:
+        return str(e)
+    except Exception as e:  # noqa: BLE001 - report any push failure to the user
+        return f"Google Calendar push failed: {e}"
+    event_repo.set_google_ids(event.id, gid, gcal_client.calendar_id)
+    event.google_event_id = gid
+    event.google_calendar_id = gcal_client.calendar_id
+    return None
+
+
+def _remove_event_from_google(google_event_id: str | None) -> None:
+    """Best-effort delete of a Google Calendar event; ignores failures."""
+    if not google_event_id:
+        return
+    with contextlib.suppress(Exception):  # removal is best-effort
+        gcal_client.delete_event(google_event_id)
 
 
 @app.command("version")
@@ -1457,6 +1487,9 @@ def event_add(
         None, "--invite", "-i", help="Comma-separated aliases/emails to invite"
     ),
     no_ai: bool = typer.Option(False, "--no-ai", help="Skip AI parsing; use flags"),
+    no_sync: bool = typer.Option(
+        False, "--no-sync", help="Don't push to Google Calendar"
+    ),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Emit result as JSON (machine-readable)"
     ),
@@ -1542,6 +1575,15 @@ def event_add(
         event_repo.set_attendees(event.id, emails)
         event.attendees = emails
 
+    # Push to Google Calendar (best-effort) unless --no-sync.
+    sync_error = None
+    if no_sync:
+        sync_error = "skipped"
+    elif not gcal_client.is_authenticated():
+        sync_error = "not-authenticated"
+    else:
+        sync_error = _push_event_to_google(event)
+
     if json_out:
         _emit_json(_event_to_dict(event))
         return
@@ -1554,7 +1596,14 @@ def event_add(
         console.print(f"[dim]Where: {event.location}[/dim]")
     if emails:
         console.print(f"[dim]Invitees: {', '.join(emails)}[/dim]")
-    console.print("[dim]Local only — Google Calendar sync lands in Phase 2.[/dim]")
+    if event.is_synced:
+        console.print("[dim]✓ Synced to Google Calendar[/dim]")
+    elif sync_error == "not-authenticated":
+        console.print(
+            "[dim]Local only — run 'todo calendar auth' to sync to Google.[/dim]"
+        )
+    elif sync_error and sync_error != "skipped":
+        console.print(f"[yellow]⚠ Not synced: {sync_error}[/yellow]")
 
 
 @event_app.command("ls")
@@ -1675,6 +1724,13 @@ def event_cancel(
         )
         return
 
+    # Remove from Google Calendar if it was synced.
+    if event.google_event_id:
+        _remove_event_from_google(event.google_event_id)
+        event_repo.set_google_ids(event_id, None, None)
+        event.google_event_id = None
+        event.google_calendar_id = None
+
     if json_out:
         _emit_json(_event_to_dict(event))
         return
@@ -1700,7 +1756,10 @@ def event_delete(
             console.print("[yellow]Aborted[/yellow]")
             return
 
+    existing = event_repo.get_by_id(event_id)
     deleted = event_repo.delete_event(event_id)
+    if deleted and existing and existing.google_event_id:
+        _remove_event_from_google(existing.google_event_id)
     if json_out:
         _emit_json({"deleted": event_id if deleted else None, "found": deleted})
         return
@@ -1710,7 +1769,131 @@ def event_delete(
         out.print(f"[red]✗ Event {event_id} not found[/red]")
 
 
+@event_app.command("sync")
+def event_sync(
+    event_id: int | None = typer.Argument(
+        None, help="Sync one event; omit to sync all unsynced"
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Push unsynced events to Google Calendar."""
+    _initialize_services()
+    out = console_err if json_out else console
+
+    if not gcal_client.is_authenticated():
+        _emit_error(out, json_out, "Not authenticated — run 'todo calendar auth' first")
+        return
+
+    if event_id is not None:
+        ev = event_repo.get_by_id(event_id)
+        if not ev:
+            _emit_error(out, json_out, f"Event {event_id} not found")
+            return
+        targets = [ev]
+    else:
+        targets = event_repo.get_unsynced()
+
+    synced: list[int] = []
+    failed: list[int] = []
+    for ev in targets:
+        if ev.is_synced:
+            continue
+        err = _push_event_to_google(ev)
+        if err:
+            failed.append(ev.id)
+            if not json_out:
+                out.print(f"[yellow]⚠ {ev.id}: {err}[/yellow]")
+        else:
+            synced.append(ev.id)
+
+    if json_out:
+        _emit_json({"synced": synced, "failed": failed})
+        return
+    console.print(f"[green]✓ Synced {len(synced)} event(s)[/green]")
+    if failed:
+        console.print(f"[red]✗ {len(failed)} failed[/red]")
+
+
 app.add_typer(event_app, name="event")
+
+
+# ---------------------------------------------------------------------------
+# Google Calendar
+# ---------------------------------------------------------------------------
+calendar_app = typer.Typer(help="Google Calendar integration")
+
+
+@calendar_app.command("auth")
+def calendar_auth(
+    no_browser: bool = typer.Option(
+        False, "--no-browser", help="Don't open a browser (print the URL instead)"
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Authenticate with Google Calendar (one-time OAuth).
+
+    Prerequisite: a Google Cloud OAuth client. Create a project, enable the
+    Google Calendar API, create an OAuth client (Desktop app), download
+    credentials.json, and save it to ~/.config/todo/gcal_credentials.json.
+    """
+    _initialize_services()
+    out = console_err if json_out else console
+
+    if not gcal_client.has_credentials():
+        _emit_error(
+            out,
+            json_out,
+            f"No OAuth credentials at {gcal_client.credentials_path}. Save your "
+            "downloaded credentials.json there, then re-run.",
+        )
+        return
+
+    try:
+        gcal_client.authenticate(open_browser=not no_browser)
+    except CalendarAuthError as e:
+        _emit_error(out, json_out, str(e))
+        return
+
+    if json_out:
+        _emit_json(
+            {
+                "authenticated": True,
+                "token_path": str(gcal_client.token_path),
+                "calendar_id": gcal_client.calendar_id,
+            }
+        )
+        return
+    console.print("[green]✓ Authenticated with Google Calendar[/green]")
+    console.print(f"[dim]Token saved to {gcal_client.token_path}[/dim]")
+
+
+@calendar_app.command("status")
+def calendar_status(
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Show Google Calendar auth status."""
+    _initialize_services()
+
+    status = {
+        "has_credentials": gcal_client.has_credentials(),
+        "authenticated": gcal_client.is_authenticated(),
+        "credentials_path": str(gcal_client.credentials_path),
+        "token_path": str(gcal_client.token_path),
+        "calendar_id": gcal_client.calendar_id,
+    }
+    if json_out:
+        _emit_json(status)
+        return
+    creds = "✓" if status["has_credentials"] else "✗ missing"
+    console.print(f"Credentials: {creds} ({status['credentials_path']})")
+    console.print(
+        "Authenticated: "
+        + ("✓" if status["authenticated"] else "✗ — run: todo calendar auth")
+    )
+    console.print(f"Calendar: {status['calendar_id']}")
+
+
+app.add_typer(calendar_app, name="calendar")
 
 
 # ---------------------------------------------------------------------------

--- a/src/todo/core/config.py
+++ b/src/todo/core/config.py
@@ -51,11 +51,26 @@ class DatabaseConfig(BaseModel):
     )
 
 
+class CalendarConfig(BaseModel):
+    """Google Calendar sync configuration."""
+
+    credentials_path: str = Field(
+        default="~/.config/todo/gcal_credentials.json",
+        description="Path to the downloaded OAuth client credentials.json",
+    )
+    token_path: str = Field(
+        default="~/.config/todo/gcal_token.json",
+        description="Path where the OAuth token is stored after auth",
+    )
+    calendar_id: str = Field(default="primary", description="Target Google calendar id")
+
+
 class AppConfig(BaseModel):
     """Main application configuration."""
 
     ai: AIConfig = Field(default_factory=AIConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+    calendar: CalendarConfig = Field(default_factory=CalendarConfig)
 
     # Application settings
     debug: bool = Field(default=False, description="Enable debug mode")
@@ -80,9 +95,18 @@ def get_app_config() -> AppConfig:
         database_path=os.getenv("TODO_DATABASE_PATH", "~/.local/share/todo/todos.db")
     )
 
+    calendar_config = CalendarConfig(
+        credentials_path=os.getenv(
+            "TODO_GCAL_CREDENTIALS", "~/.config/todo/gcal_credentials.json"
+        ),
+        token_path=os.getenv("TODO_GCAL_TOKEN", "~/.config/todo/gcal_token.json"),
+        calendar_id=os.getenv("TODO_GCAL_CALENDAR_ID", "primary"),
+    )
+
     return AppConfig(
         ai=ai_config,
         database=database_config,
+        calendar=calendar_config,
         debug=os.getenv("TODO_DEBUG", "false").lower() == "true",
         log_level=os.getenv("TODO_LOG_LEVEL", "INFO").upper(),
     )

--- a/src/todo/db/repository.py
+++ b/src/todo/db/repository.py
@@ -1223,6 +1223,31 @@ class EventRepository(BaseRepository[Event]):
         ).fetchall()
         return [r[0] for r in rows]
 
+    def set_google_ids(
+        self, event_id: int, google_event_id: str | None, calendar_id: str | None
+    ) -> None:
+        """Record (or clear) the Google Calendar sync identifiers for an event."""
+        conn = self.db.connect()
+        conn.execute(
+            "UPDATE events SET google_event_id = ?, google_calendar_id = ?, "
+            "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            [google_event_id, calendar_id, event_id],
+        )
+
+    def get_unsynced(self) -> list[Event]:
+        """Scheduled events not yet pushed to Google (no google_event_id)."""
+        conn = self.db.connect()
+        cursor = conn.execute(
+            "SELECT * FROM events WHERE status = 'scheduled' "
+            "AND google_event_id IS NULL ORDER BY start_at ASC"
+        )
+        rows = cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+        events = [self._row_to_model(dict(zip(cols, r))) for r in rows]
+        for event in events:
+            event.attendees = self.get_attendees(event.id)
+        return events
+
 
 class ContactRepository(BaseRepository[Contact]):
     """Repository for contact-alias operations."""

--- a/src/todo/gcal/__init__.py
+++ b/src/todo/gcal/__init__.py
@@ -1,0 +1,1 @@
+"""Google Calendar integration (one-way push)."""

--- a/src/todo/gcal/client.py
+++ b/src/todo/gcal/client.py
@@ -1,0 +1,107 @@
+"""Google Calendar client — one-way push of local events via gcsa.
+
+gcsa (and the Google client libraries) are imported lazily so the rest of the
+app, and the test suite, don't require them or any network/credentials.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..core.config import CalendarConfig
+    from ..models import Event
+
+
+class CalendarAuthError(RuntimeError):
+    """Raised when Google Calendar auth is missing, invalid, or fails."""
+
+
+class GoogleCalendarClient:
+    """Thin wrapper over gcsa for pushing events to Google Calendar."""
+
+    def __init__(self, config: CalendarConfig) -> None:
+        self.calendar_id = config.calendar_id
+        self.credentials_path = Path(config.credentials_path).expanduser()
+        self.token_path = Path(config.token_path).expanduser()
+        self._calendar = None  # cached gcsa GoogleCalendar
+
+    # -- state ---------------------------------------------------------------
+
+    def has_credentials(self) -> bool:
+        """Whether the OAuth client credentials.json is present."""
+        return self.credentials_path.exists()
+
+    def is_authenticated(self) -> bool:
+        """Whether an OAuth token has been stored (auth completed at least once)."""
+        return self.token_path.exists()
+
+    # -- connection ----------------------------------------------------------
+
+    def _connect(self, *, open_browser: bool):
+        """Return a connected gcsa GoogleCalendar, running the OAuth flow if needed."""
+        if self._calendar is not None:
+            return self._calendar
+        if not self.has_credentials():
+            raise CalendarAuthError(
+                f"No OAuth credentials at {self.credentials_path}. Create a Google "
+                "Cloud OAuth client (Desktop app), download credentials.json, and "
+                "save it there (see 'todo calendar auth')."
+            )
+        self.token_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            from gcsa.google_calendar import GoogleCalendar
+
+            self._calendar = GoogleCalendar(
+                default_calendar=self.calendar_id,
+                credentials_path=str(self.credentials_path),
+                token_path=str(self.token_path),
+                open_browser=open_browser,
+            )
+        except CalendarAuthError:
+            raise
+        except Exception as e:  # noqa: BLE001 - surface any auth/library failure
+            raise CalendarAuthError(f"Google Calendar auth failed: {e}") from e
+        return self._calendar
+
+    def authenticate(self, *, open_browser: bool = True) -> None:
+        """Run the OAuth flow (opening a browser if needed) and store the token."""
+        self._connect(open_browser=open_browser)
+
+    # -- event ops -----------------------------------------------------------
+
+    def _to_gcsa_event(self, event: Event):
+        from gcsa.event import Event as GEvent
+
+        if event.all_day:
+            start = event.start_at.date()
+            end = (event.end_at or event.start_at).date() + timedelta(days=1)
+        else:
+            start = event.start_at
+            end = event.end_at or (event.start_at + timedelta(hours=1))
+        return GEvent(
+            event.title,
+            start=start,
+            end=end,
+            description=event.description,
+            location=event.location,
+            event_id=event.google_event_id,  # None on create, set on update
+        )
+
+    def push_event(self, event: Event) -> str:
+        """Create the event in Google Calendar; return its Google event id."""
+        gc = self._connect(open_browser=False)
+        created = gc.add_event(self._to_gcsa_event(event), calendar_id=self.calendar_id)
+        return created.event_id
+
+    def update_event(self, event: Event) -> None:
+        """Update an already-synced event in Google Calendar."""
+        gc = self._connect(open_browser=False)
+        gc.update_event(self._to_gcsa_event(event), calendar_id=self.calendar_id)
+
+    def delete_event(self, google_event_id: str) -> None:
+        """Delete an event from Google Calendar by its Google event id."""
+        gc = self._connect(open_browser=False)
+        gc.delete_event(google_event_id, calendar_id=self.calendar_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1261,3 +1261,162 @@ class TestCLIDoneNote:
         mock_todo_repo.complete_todo.assert_called_once_with(
             1, note="paid via portal #8891"
         )
+
+
+class TestCLICalendar:
+    """Tests for the calendar sub-app and event sync."""
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.gcal_client")
+    def test_calendar_status_json(
+        self, mock_gcal, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.has_credentials.return_value = False
+        mock_gcal.is_authenticated.return_value = False
+        mock_gcal.credentials_path = "/x/creds.json"
+        mock_gcal.token_path = "/x/token.json"
+        mock_gcal.calendar_id = "primary"
+
+        result = runner.invoke(app, ["calendar", "status", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["has_credentials"] is False
+        assert payload["authenticated"] is False
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.gcal_client")
+    def test_calendar_auth_without_credentials(
+        self, mock_gcal, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.has_credentials.return_value = False
+        mock_gcal.credentials_path = "/x/creds.json"
+
+        result = runner.invoke(app, ["calendar", "auth", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())
+        mock_gcal.authenticate.assert_not_called()
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_sync_not_authenticated(
+        self, mock_gcal, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.is_authenticated.return_value = False
+
+        result = runner.invoke(app, ["event", "sync", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_sync_pushes_unsynced(
+        self, mock_gcal, mock_events, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.is_authenticated.return_value = True
+        mock_gcal.calendar_id = "primary"
+        mock_gcal.push_event.return_value = "g_1"
+        ev = _make_mock_event()
+        ev.is_synced = False
+        mock_events.get_unsynced.return_value = [ev]
+
+        result = runner.invoke(app, ["event", "sync", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["synced"] == [1]
+        assert payload["failed"] == []
+        mock_events.set_google_ids.assert_called_once_with(1, "g_1", "primary")
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_add_pushes_when_authed(
+        self,
+        mock_gcal,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.resolve.return_value = []
+        mock_gcal.is_authenticated.return_value = True
+        mock_gcal.calendar_id = "primary"
+        mock_gcal.push_event.return_value = "g_99"
+        mock_events.create_event.return_value = _make_mock_event()
+
+        result = runner.invoke(
+            app,
+            [
+                "event",
+                "add",
+                "Soccer",
+                "--when",
+                "2026-06-13 10:00",
+                "--no-ai",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_gcal.push_event.assert_called_once()
+        mock_events.set_google_ids.assert_called_once_with(1, "g_99", "primary")
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_add_no_sync_skips_push(
+        self,
+        mock_gcal,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.resolve.return_value = []
+        mock_gcal.is_authenticated.return_value = True
+        mock_events.create_event.return_value = _make_mock_event()
+
+        result = runner.invoke(
+            app,
+            [
+                "event",
+                "add",
+                "Soccer",
+                "--when",
+                "2026-06-13 10:00",
+                "--no-ai",
+                "--no-sync",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_gcal.push_event.assert_not_called()

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -1,0 +1,73 @@
+"""Tests for the Google Calendar client (gcsa wrapper)."""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from todo.core.config import CalendarConfig
+from todo.gcal.client import CalendarAuthError, GoogleCalendarClient
+from todo.models import Event
+
+
+def _client(tmp: Path, *, creds: bool = True, token: bool = False):
+    creds_p = tmp / "creds.json"
+    token_p = tmp / "token.json"
+    if creds:
+        creds_p.write_text("{}")
+    if token:
+        token_p.write_text("{}")
+    cfg = CalendarConfig(
+        credentials_path=str(creds_p),
+        token_path=str(token_p),
+        calendar_id="primary",
+    )
+    return GoogleCalendarClient(cfg)
+
+
+def test_auth_state_reflects_files(tmp_path):
+    a = tmp_path / "a"
+    a.mkdir()
+    c = _client(a, creds=True, token=False)
+    assert c.has_credentials() is True
+    assert c.is_authenticated() is False
+
+    b = tmp_path / "b"
+    b.mkdir()
+    c2 = _client(b, creds=False, token=True)
+    assert c2.has_credentials() is False
+    assert c2.is_authenticated() is True
+
+
+def test_connect_without_credentials_raises(tmp_path):
+    c = _client(tmp_path, creds=False)
+    with pytest.raises(CalendarAuthError):
+        c.authenticate(open_browser=False)
+
+
+def test_push_event_returns_google_id(tmp_path):
+    c = _client(tmp_path, creds=True)
+    fake_cal = Mock()
+    fake_cal.add_event.return_value = Mock(event_id="g_123")
+    with patch.object(c, "_connect", return_value=fake_cal):
+        ev = Event(title="Dinner", start_at=datetime(2026, 6, 12, 19, 0))
+        gid = c.push_event(ev)
+    assert gid == "g_123"
+    fake_cal.add_event.assert_called_once()
+
+
+def test_delete_event_calls_gcsa(tmp_path):
+    c = _client(tmp_path, creds=True)
+    fake_cal = Mock()
+    with patch.object(c, "_connect", return_value=fake_cal):
+        c.delete_event("g_123")
+    fake_cal.delete_event.assert_called_once_with("g_123", calendar_id="primary")
+
+
+def test_all_day_event_uses_dates(tmp_path):
+    c = _client(tmp_path, creds=True)
+    ev = Event(title="Vacation", start_at=datetime(2026, 6, 20, 0, 0), all_day=True)
+    gevent = c._to_gcsa_event(ev)
+    # gcsa stores all-day events with date (not datetime) start/end
+    assert not isinstance(gevent.start, datetime)

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,18 @@ wheels = [
 ]
 
 [[package]]
+name = "beautiful-date"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/cd/da33e942d76ae5294763e62fb4e6504a3bc184618f6e78ec6a0f9c8ae05e/beautiful-date-2.3.0.tar.gz", hash = "sha256:bb9db8f572298ce992a1d7542a22e2bb4959c401bfd451ab02dcbf2732054879", size = 7943, upload-time = "2023-09-15T09:23:15.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/48/5754e015612d79d36d4da499941f8e433a9ce8e96be98fab99dc5511f662/beautiful_date-2.3.0-py2.py3-none-any.whl", hash = "sha256:5d11a87ae24912d78bc0d30db21052b68011a65e1070647eb09d2e11a1f1a610", size = 8153, upload-time = "2023-09-15T09:23:14.186Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.40.21"
 source = { registry = "https://pypi.org/simple" }
@@ -430,6 +442,23 @@ wheels = [
 ]
 
 [[package]]
+name = "gcsa"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautiful-date" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/e3/22b6a7628ad8334fd4a62bf90ac2f40cad73675c4663e718b097f15d2d55/gcsa-2.6.0.tar.gz", hash = "sha256:1181ff6bf409b165b872788827a67e7a280cbba784a7b86aef57eeca8d216e9b", size = 53239, upload-time = "2025-08-22T11:39:05.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c4/6e1ae85ce9d707f1e441716626c0b11c578cf4af4917f969673c60442514/gcsa-2.6.0-py2.py3-none-any.whl", hash = "sha256:fcc495ffc0364d09f873e74214f6692a95fc64d7e12237cde4de68d00be9511f", size = 49634, upload-time = "2025-08-22T11:39:04.324Z" },
+]
+
+[[package]]
 name = "genai-prices"
 version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
@@ -440,6 +469,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/3d/59c5d4d83999acb09e3c8062e34a73969db88d18353d55b3eed495d32921/genai_prices-0.0.24.tar.gz", hash = "sha256:faeac6276964bc31ca9a2551219d4642979426bd2c593e884ec5bb40089b298e", size = 44702, upload-time = "2025-08-26T12:12:57.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/d4/48ec6b327c2ba8c381a10484dd97f15e6b51a1ea708dc783e71fc5e01234/genai_prices-0.0.24-py3-none-any.whl", hash = "sha256:620beb35a845b32463201bb2816060181500e15c0a715b3bfa2583ef58e0702d", size = 47028, upload-time = "2025-08-26T12:12:56.162Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.197.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/081d66357118bd260f8f182cb1b2dd5bd32ca88e3714d7c93896cab946fc/google_api_python_client-2.197.0.tar.gz", hash = "sha256:32e03977eda4a66eafc6ae58dc9ec46426b6025636d5ef019c5703013eddd4e5", size = 14707398, upload-time = "2026-05-28T20:23:12.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e5/e9cc221fd75230974d4ef45eb72d2261feca3c110d5554215d516bfe6534/google_api_python_client-2.197.0-py3-none-any.whl", hash = "sha256:0f8b89aa75768161dd4f5092d6bcb386c13236b32e0d9a938c02f71342094d14", size = 15287302, upload-time = "2026-05-28T20:23:09.683Z" },
 ]
 
 [[package]]
@@ -454,6 +515,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
 ]
 
 [[package]]
@@ -473,6 +560,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/03/ab/e6cdd8fa957c647ef00c4da7c59d0e734354bd49ed8d98c860732d8e1944/google_genai-1.32.0.tar.gz", hash = "sha256:349da3f5ff0e981066bd508585fcdd308d28fc4646f318c8f6d1aa6041f4c7e3", size = 240802, upload-time = "2025-08-27T22:16:32.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/55/be09472f7a656af1208196d2ef9a3d2710f3cbcf695f51acbcbe28b9472b/google_genai-1.32.0-py3-none-any.whl", hash = "sha256:c0c4b1d45adf3aa99501050dd73da2f0dea09374002231052d81a6765d15e7f6", size = 241680, upload-time = "2025-08-27T22:16:31.409Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -539,6 +638,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -881,6 +992,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "openai"
 version = "1.102.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1015,6 +1135,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
 ]
 
 [[package]]
@@ -1234,6 +1366,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1520,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -1596,6 +1750,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "click" },
     { name = "duckdb" },
+    { name = "gcsa" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
@@ -1638,6 +1793,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.6.0" },
     { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "gcsa", specifier = ">=2.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "openai", specifier = ">=1.40.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.8.0" },
@@ -1771,6 +1927,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 2 of SB-124. One-way push of local events to Google Calendar.

## What
- **`gcal/client.py`** — `GoogleCalendarClient` over `gcsa` (lazy import): `authenticate`, `push_event`, `update_event`, `delete_event`; maps a local `Event` → gcsa event (all-day events use dates).
- **config** — `CalendarConfig` (credentials/token paths, `calendar_id`) via env (`TODO_GCAL_*`). Defaults under `~/.config/todo/`.
- **CLI**
  - `todo calendar auth` — one-time OAuth (opens browser); `calendar status` shows auth state.
  - `event add` pushes to Google unless `--no-sync`; **graceful no-op** when not authenticated (stays local with a hint).
  - `event sync [<id>]` — push unsynced events.
  - `event cancel` / `delete` — also remove the Google event.
  - Stores `google_event_id` / `google_calendar_id` on the local row; `is_synced` in JSON.
- **repo** — `EventRepository.set_google_ids` / `get_unsynced`.

## Testing
gcsa + Google libs are imported lazily, so the app and the suite need **no Google setup**. Tests mock the client + gcsa (`test_gcal.py`, calendar CLI tests). Full suite back to the pre-existing baseline (17 unrelated isolation failures).

## Prerequisite (manual, one-time per machine)
Create a Google Cloud project → enable Calendar API → OAuth client (**Desktop app**) → download `credentials.json` → save to `~/.config/todo/gcal_credentials.json` → `todo calendar auth`. Set the consent screen to **Production** to avoid 7-day token expiry.

## Not in this PR
Attendee invites (SB-127), two-way pull (SB-128).

Fixes SB-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)