### PR TITLE
Events Phase 3: send calendar invites (SB-127)

### DIFF
--- a/src/todo/cli/main.py
+++ b/src/todo/cli/main.py
@@ -184,13 +184,14 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
     }
 
 
-def _push_event_to_google(event: Any) -> str | None:
+def _push_event_to_google(event: Any, *, send_invites: bool = False) -> str | None:
     """Push an event to Google Calendar and persist its id.
 
-    Returns None on success, or an error message string on failure.
+    Attendees are emailed only when ``send_invites`` is True. Returns None on
+    success, or an error message string on failure.
     """
     try:
-        gid = gcal_client.push_event(event)
+        gid = gcal_client.push_event(event, send_invites=send_invites)
     except CalendarAuthError as e:
         return str(e)
     except Exception as e:  # noqa: BLE001 - report any push failure to the user
@@ -1490,6 +1491,12 @@ def event_add(
     no_sync: bool = typer.Option(
         False, "--no-sync", help="Don't push to Google Calendar"
     ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Send invites without confirming"
+    ),
+    no_invite: bool = typer.Option(
+        False, "--no-invite", help="Sync the event but don't invite anyone"
+    ),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Emit result as JSON (machine-readable)"
     ),
@@ -1575,14 +1582,24 @@ def event_add(
         event_repo.set_attendees(event.id, emails)
         event.attendees = emails
 
-    # Push to Google Calendar (best-effort) unless --no-sync.
+    # Push to Google Calendar (best-effort) unless --no-sync. Invites (emails to
+    # attendees) only go out on explicit confirmation / --yes.
     sync_error = None
+    send_invites = False
     if no_sync:
         sync_error = "skipped"
     elif not gcal_client.is_authenticated():
         sync_error = "not-authenticated"
     else:
-        sync_error = _push_event_to_google(event)
+        if emails and not no_invite:
+            if yes:
+                send_invites = True
+            elif not json_out:
+                send_invites = typer.confirm(
+                    f"Send calendar invites to {', '.join(emails)}?"
+                )
+            # JSON / non-interactive without --yes: don't email (safe default).
+        sync_error = _push_event_to_google(event, send_invites=send_invites)
 
     if json_out:
         _emit_json(_event_to_dict(event))
@@ -1597,7 +1614,12 @@ def event_add(
     if emails:
         console.print(f"[dim]Invitees: {', '.join(emails)}[/dim]")
     if event.is_synced:
-        console.print("[dim]✓ Synced to Google Calendar[/dim]")
+        msg = "✓ Synced to Google Calendar"
+        if send_invites:
+            msg += f" · invited {len(emails)}"
+        elif emails:
+            msg += " (no invites sent — use --yes or 'todo event invite')"
+        console.print(f"[dim]{msg}[/dim]")
     elif sync_error == "not-authenticated":
         console.print(
             "[dim]Local only — run 'todo calendar auth' to sync to Google.[/dim]"
@@ -1812,6 +1834,74 @@ def event_sync(
     console.print(f"[green]✓ Synced {len(synced)} event(s)[/green]")
     if failed:
         console.print(f"[red]✗ {len(failed)} failed[/red]")
+
+
+@event_app.command("invite")
+def event_invite(
+    event_id: int,
+    tokens: list[str] = typer.Argument(
+        None, help="Extra aliases/emails to add before inviting"
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirm prompt"),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Send Google Calendar invites to an event's attendees.
+
+    Optionally add more invitees first:
+        todo event invite 12 family
+    """
+    _initialize_services()
+    out = console_err if json_out else console
+
+    if not gcal_client.is_authenticated():
+        _emit_error(out, json_out, "Not authenticated — run 'todo calendar auth'")
+        return
+
+    event = event_repo.get_by_id(event_id)
+    if not event:
+        _emit_error(out, json_out, f"Event {event_id} not found")
+        return
+
+    if tokens:
+        new_emails = contact_repo.resolve(tokens)
+        merged = list(dict.fromkeys(list(event.attendees) + new_emails))
+        event_repo.set_attendees(event_id, merged)
+        event.attendees = merged
+
+    if not event.attendees:
+        _emit_error(
+            out, json_out, "No invitees — add some: todo event invite <id> wife kids"
+        )
+        return
+
+    if (
+        not yes
+        and not json_out
+        and not typer.confirm(f"Send calendar invites to {', '.join(event.attendees)}?")
+    ):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    try:
+        if event.is_synced:
+            gcal_client.update_event(event, send_invites=True)
+        else:
+            gid = gcal_client.push_event(event, send_invites=True)
+            event_repo.set_google_ids(event_id, gid, gcal_client.calendar_id)
+            event.google_event_id = gid
+    except CalendarAuthError as e:
+        _emit_error(out, json_out, str(e))
+        return
+    except Exception as e:  # noqa: BLE001 - surface push/update failure
+        _emit_error(out, json_out, f"Invite failed: {e}")
+        return
+
+    if json_out:
+        _emit_json({"event_id": event_id, "invited": event.attendees})
+        return
+    console.print(
+        f"[green]✓ Invited {len(event.attendees)}:[/green] {', '.join(event.attendees)}"
+    )
 
 
 app.add_typer(event_app, name="event")

--- a/src/todo/gcal/client.py
+++ b/src/todo/gcal/client.py
@@ -72,7 +72,7 @@ class GoogleCalendarClient:
 
     # -- event ops -----------------------------------------------------------
 
-    def _to_gcsa_event(self, event: Event):
+    def _to_gcsa_event(self, event: Event, *, with_attendees: bool):
         from gcsa.event import Event as GEvent
 
         if event.all_day:
@@ -87,19 +87,36 @@ class GoogleCalendarClient:
             end=end,
             description=event.description,
             location=event.location,
+            attendees=list(event.attendees) if with_attendees else None,
             event_id=event.google_event_id,  # None on create, set on update
         )
 
-    def push_event(self, event: Event) -> str:
-        """Create the event in Google Calendar; return its Google event id."""
+    @staticmethod
+    def _send_updates(send_invites: bool) -> str:
+        # 'all' emails every guest; 'none' adds guests silently (no email).
+        return "all" if send_invites else "none"
+
+    def push_event(self, event: Event, *, send_invites: bool = False) -> str:
+        """Create the event in Google Calendar; return its Google event id.
+
+        Attendees are attached (and emailed) only when ``send_invites`` is True.
+        """
         gc = self._connect(open_browser=False)
-        created = gc.add_event(self._to_gcsa_event(event), calendar_id=self.calendar_id)
+        created = gc.add_event(
+            self._to_gcsa_event(event, with_attendees=send_invites),
+            send_updates=self._send_updates(send_invites),
+            calendar_id=self.calendar_id,
+        )
         return created.event_id
 
-    def update_event(self, event: Event) -> None:
-        """Update an already-synced event in Google Calendar."""
+    def update_event(self, event: Event, *, send_invites: bool = False) -> None:
+        """Update an already-synced event; emails guests when ``send_invites``."""
         gc = self._connect(open_browser=False)
-        gc.update_event(self._to_gcsa_event(event), calendar_id=self.calendar_id)
+        gc.update_event(
+            self._to_gcsa_event(event, with_attendees=send_invites),
+            send_updates=self._send_updates(send_invites),
+            calendar_id=self.calendar_id,
+        )
 
     def delete_event(self, google_event_id: str) -> None:
         """Delete an event from Google Calendar by its Google event id."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1420,3 +1420,135 @@ class TestCLICalendar:
 
         assert result.exit_code == 0
         mock_gcal.push_event.assert_not_called()
+
+
+class TestCLIInvites:
+    """Tests for sending Google Calendar invites (Phase 3)."""
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_add_with_yes_sends_invites(
+        self,
+        mock_gcal,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.resolve.return_value = ["keri@x.com"]
+        mock_gcal.is_authenticated.return_value = True
+        mock_gcal.calendar_id = "primary"
+        mock_gcal.push_event.return_value = "g_1"
+        mock_events.create_event.return_value = _make_mock_event()
+
+        result = runner.invoke(
+            app,
+            [
+                "event",
+                "add",
+                "Dinner",
+                "--when",
+                "2026-06-13 18:00",
+                "--invite",
+                "wife",
+                "--no-ai",
+                "--yes",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert mock_gcal.push_event.call_args.kwargs["send_invites"] is True
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_add_json_does_not_send_invites_without_yes(
+        self,
+        mock_gcal,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_contacts.resolve.return_value = ["keri@x.com"]
+        mock_gcal.is_authenticated.return_value = True
+        mock_gcal.calendar_id = "primary"
+        mock_gcal.push_event.return_value = "g_1"
+        mock_events.create_event.return_value = _make_mock_event()
+
+        result = runner.invoke(
+            app,
+            [
+                "event",
+                "add",
+                "Dinner",
+                "--when",
+                "2026-06-13 18:00",
+                "--invite",
+                "wife",
+                "--no-ai",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # safe default: synced but no email sent
+        assert mock_gcal.push_event.call_args.kwargs["send_invites"] is False
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.event_repo")
+    @patch("todo.cli.main.contact_repo")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_invite_updates_synced_event(
+        self,
+        mock_gcal,
+        mock_contacts,
+        mock_events,
+        mock_mig,
+        mock_db,
+        mock_config,
+        runner,
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.is_authenticated.return_value = True
+        ev = _make_mock_event(attendees=["keri@x.com", "elise@x.com"])
+        ev.is_synced = True
+        mock_events.get_by_id.return_value = ev
+
+        result = runner.invoke(app, ["event", "invite", "1", "--yes", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["invited"] == ["keri@x.com", "elise@x.com"]
+        assert mock_gcal.update_event.call_args.kwargs["send_invites"] is True
+
+    @patch("todo.cli.main.config")
+    @patch("todo.cli.main.db")
+    @patch("todo.cli.main.migration_manager")
+    @patch("todo.cli.main.gcal_client")
+    def test_event_invite_not_authenticated(
+        self, mock_gcal, mock_mig, mock_db, mock_config, runner
+    ):
+        mock_mig.is_schema_initialized.return_value = True
+        mock_gcal.is_authenticated.return_value = False
+
+        result = runner.invoke(app, ["event", "invite", "1", "--json"])
+
+        assert result.exit_code == 0
+        assert "error" in json.loads(result.stdout.strip())

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -68,6 +68,38 @@ def test_delete_event_calls_gcsa(tmp_path):
 def test_all_day_event_uses_dates(tmp_path):
     c = _client(tmp_path, creds=True)
     ev = Event(title="Vacation", start_at=datetime(2026, 6, 20, 0, 0), all_day=True)
-    gevent = c._to_gcsa_event(ev)
+    gevent = c._to_gcsa_event(ev, with_attendees=False)
     # gcsa stores all-day events with date (not datetime) start/end
     assert not isinstance(gevent.start, datetime)
+
+
+def test_push_with_invites_sets_send_updates_all(tmp_path):
+    c = _client(tmp_path, creds=True)
+    fake_cal = Mock()
+    fake_cal.add_event.return_value = Mock(event_id="g")
+    with patch.object(c, "_connect", return_value=fake_cal):
+        ev = Event(
+            title="Dinner",
+            start_at=datetime(2026, 6, 12, 19, 0),
+            attendees=["a@x.com", "b@x.com"],
+        )
+        c.push_event(ev, send_invites=True)
+    assert fake_cal.add_event.call_args.kwargs["send_updates"] == "all"
+    gevent = fake_cal.add_event.call_args.args[0]
+    assert sorted(a.email for a in gevent.attendees) == ["a@x.com", "b@x.com"]
+
+
+def test_push_without_invites_omits_attendees(tmp_path):
+    c = _client(tmp_path, creds=True)
+    fake_cal = Mock()
+    fake_cal.add_event.return_value = Mock(event_id="g")
+    with patch.object(c, "_connect", return_value=fake_cal):
+        ev = Event(
+            title="Dinner",
+            start_at=datetime(2026, 6, 12, 19, 0),
+            attendees=["a@x.com"],
+        )
+        c.push_event(ev, send_invites=False)
+    assert fake_cal.add_event.call_args.kwargs["send_updates"] == "none"
+    gevent = fake_cal.add_event.call_args.args[0]
+    assert not gevent.attendees


### PR DESCRIPTION
Phase 3 of SB-124. Send Google Calendar invites to event attendees (resolved from contact aliases).

## What
- **gcal client:** `push_event`/`update_event` take `send_invites`. Attendees are attached to the Google event and **emailed only when `send_invites=True`** (`send_updates` `all` vs `none`).
- **`event add`:** `--yes/-y` sends invites; `--no-invite` skips; interactive mode **prompts before emailing**; JSON / non-interactive without `--yes` does **not** email (safe default — the event still syncs).
- **`todo event invite <id> [aliases...]`** — (re)send invites for an event, optionally adding more invitees first (e.g. `todo event invite 12 family`).

## Safety
Real emails go out only on an explicit `--yes` or an interactive confirm. Scripts/JSON never send silently.

## Testing
Client tests assert the `send_updates` wiring and attendee attach/omit; CLI tests cover the safe no-email defaults and the invite command. Full suite back to the pre-existing baseline (17 unrelated isolation failures).

Fixes SB-127

🤖 Generated with [Claude Code](https://claude.com/claude-code)